### PR TITLE
Fixed byte counts

### DIFF
--- a/pcaphistogram.py
+++ b/pcaphistogram.py
@@ -10,13 +10,13 @@ def processpacket(packet):
 
     data = ''
     if (TCP in packet):
-        data = str(packet[TCP].payload)
+        data = bytes(packet[TCP].payload)
     elif (UDP in packet):
-        data = str(packet[UDP].payload)
+        data = bytes(packet[UDP].payload)
 
     if (data != ''):
         for byte in data:
-            databytes[ord(byte)] += 1
+            databytes[byte] += 1
 
 
 


### PR DESCRIPTION
Your original code was converting the TCP/UDP payloads to UTF-8 then looking up the ORD.  This worked OK when looking at ASCII and UTF-8 payloads, but absolutely failed when looking at binary and 16/32-bit unicode payloads.